### PR TITLE
perf: improve Discord API access performance and upgrade Go to 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26.1 AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jedipunkz/discord-exporter
 
-go 1.25.3
+go 1.26.1
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0

--- a/main.go
+++ b/main.go
@@ -104,17 +104,18 @@ func parseExcludedChannels(channelsStr string) map[string]struct{} {
 	return excluded
 }
 
-// updateMemberCount fetches and updates the member count metric
+// updateMemberCount fetches and updates the member count metric.
+// Uses Guild API to get the member count in a single API call instead of
+// paginating through all members.
 func updateMemberCount(session *discordgo.Session, serverID string) {
-	members, err := session.GuildMembers(serverID, "", maxMembersPerRequest)
+	guild, err := session.Guild(serverID)
 	if err != nil {
-		log.Printf("Failed to get guild members: %v", err)
+		log.Printf("Failed to get guild: %v", err)
 		return
 	}
 
-	memberCount := len(members)
-	memberCountGauge.Set(float64(memberCount))
-	log.Printf("Member count: %d", memberCount)
+	memberCountGauge.Set(float64(guild.MemberCount))
+	log.Printf("Member count: %d", guild.MemberCount)
 }
 
 // countChannelMessages counts messages in a channel using incremental counting.
@@ -313,13 +314,32 @@ func updateMessageCount(session *discordgo.Session, config *Config) {
 	log.Printf("Message count update completed in %v (%d successful, %d errors)", elapsed, successCount, errorCount)
 }
 
-// startMetricsCollector starts a goroutine that periodically updates metrics
+// collectMetrics runs both metric updates concurrently and waits for both to finish.
+func collectMetrics(session *discordgo.Session, config *Config) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		updateMemberCount(session, config.ServerID)
+	}()
+	go func() {
+		defer wg.Done()
+		updateMessageCount(session, config)
+	}()
+	wg.Wait()
+}
+
+// startMetricsCollector starts a goroutine that periodically updates metrics.
+// Uses a ticker so the interval is wall-clock based regardless of how long
+// each collection takes.
 func startMetricsCollector(session *discordgo.Session, config *Config) {
 	go func() {
-		for {
-			updateMemberCount(session, config.ServerID)
-			updateMessageCount(session, config)
-			time.Sleep(defaultUpdateInterval)
+		collectMetrics(session, config)
+
+		ticker := time.NewTicker(defaultUpdateInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			collectMetrics(session, config)
 		}
 	}()
 }


### PR DESCRIPTION
## Summary

- **Replace `GuildMembers` with `Guild` API for member count**: The previous implementation listed all members (up to 1000) to count them. Using `session.Guild()` retrieves the member count in a single API call, reducing Discord API usage and removing the 1000-member cap.
- **Concurrent metric collection**: Member count and message count updates are now run in parallel via goroutines, reducing total collection time.
- **Switch from `time.Sleep` to `time.Ticker`**: The collection interval is now wall-clock based. Previously, if a collection took 5 minutes, the next run would start 20 minutes after the previous one began (15m interval + 5m execution). With a ticker, it fires every 15 minutes regardless of execution duration.
- **Upgrade Go to 1.26.1**: Updated both `go.mod` and `Dockerfile`.

## Test plan

- [ ] Verify member count metric is accurate for servers with >1000 members
- [ ] Verify both member count and message count metrics are updated each interval
- [ ] Verify collection interval remains consistent under slow API conditions
- [ ] Build Docker image and confirm it uses `golang:1.26.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)