### PR TITLE
fix: member count always returns 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,17 +94,17 @@ func parseExcludedChannels(channelsStr string) map[string]struct{} {
 }
 
 // updateMemberCount fetches and updates the member count metric.
-// Uses Guild API to get the member count in a single API call instead of
-// paginating through all members.
+// Uses GuildWithCounts API to get the member count with with_counts=true
+// so that ApproximateMemberCount is populated.
 func updateMemberCount(session *discordgo.Session, serverID string) {
-	guild, err := session.Guild(serverID)
+	guild, err := session.GuildWithCounts(serverID)
 	if err != nil {
 		log.Printf("Failed to get guild: %v", err)
 		return
 	}
 
-	memberCountGauge.Set(float64(guild.MemberCount))
-	log.Printf("Member count: %d", guild.MemberCount)
+	memberCountGauge.Set(float64(guild.ApproximateMemberCount))
+	log.Printf("Member count: %d", guild.ApproximateMemberCount)
 }
 
 // countChannelMessages counts all messages in a given channel


### PR DESCRIPTION
## Summary

- `session.Guild()` calls `GET /guilds/{id}` without `with_counts=true`, causing `MemberCount` to always be `0`
- Introduced in #8 when switching from `GuildMembers` pagination to a single Guild API call
- Fix: use `session.GuildWithCounts()` which appends `?with_counts=true`, and read `ApproximateMemberCount` instead of `MemberCount`

## Root Cause

The Discord REST API only populates `member_count` on gateway events (WebSocket). When fetching via REST without `with_counts=true`, the field is omitted and defaults to `0`. The `with_counts=true` parameter returns `approximate_member_count` which reflects the actual guild member count.

## Test plan

- [ ] Deploy and confirm `discord_members_count` metric is non-zero
- [ ] Verify count matches the member count shown in Discord server settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)